### PR TITLE
Allow an empty description for photo card

### DIFF
--- a/twitter-card.php
+++ b/twitter-card.php
@@ -162,7 +162,7 @@ class Twitter_Card {
 	public function setDescription( $description ) {
 		if ( is_string( $description ) ) {
 			$description = trim( $description );
-			if ( $description )
+			if ( $description || $this->card === 'photo' )
 				$this->description = $description;
 		}
 		return $this;


### PR DESCRIPTION
In the Twitter Card docs it says, that photo cards don't need a description. The class should respect that.
